### PR TITLE
Improved CPACS parsing speed

### DIFF
--- a/src/SchemaParser.cpp
+++ b/src/SchemaParser.cpp
@@ -6,7 +6,7 @@
 namespace tigl {
     SchemaParser::SchemaParser(const std::string& cpacsLocation)
         : document(tixihelper::TixiDocument::createFromFile(cpacsLocation)) {
-        document.registerNamespaces("http://www.w3.org/2001/XMLSchema", "xsd");
+        document.registerNamespace("http://www.w3.org/2001/XMLSchema", "xsd");
 
         document.forEachChild("/xsd:schema/xsd:simpleType", [&](const std::string& xpath) {
             readSimpleType(xpath);

--- a/src/SchemaParser.cpp
+++ b/src/SchemaParser.cpp
@@ -6,6 +6,8 @@
 namespace tigl {
     SchemaParser::SchemaParser(const std::string& cpacsLocation)
         : document(tixihelper::TixiDocument::createFromFile(cpacsLocation)) {
+        document.registerNamespaces("http://www.w3.org/2001/XMLSchema", "xsd");
+
         document.forEachChild("/xsd:schema/xsd:simpleType", [&](const std::string& xpath) {
             readSimpleType(xpath);
         });

--- a/src/TixiDocument.h
+++ b/src/TixiDocument.h
@@ -32,7 +32,6 @@ namespace tigl {
 
             static TixiDocument createFromFile(const std::string& filename) {
                 TixiDocument doc(TixiOpenDocument(filename));
-                doc.registerNamespaces();
                 return doc;
             }
 
@@ -180,6 +179,10 @@ namespace tigl {
 
             void registerNamespaces() {
                 TixiRegisterNamespacesFromDocument(m_handle);
+            }
+
+            void registerNamespaces(const std::string& namespaceURI, const std::string& prefix) {
+                TixiRegisterNamespace(m_handle, namespaceURI, prefix);
             }
 
             const TixiDocumentHandle& handle() const {

--- a/src/TixiDocument.h
+++ b/src/TixiDocument.h
@@ -41,7 +41,6 @@ namespace tigl {
 
             static TixiDocument createFromString(const std::string& xml) {
                 TixiDocument doc(TixiImportFromString(xml));
-                doc.registerNamespaces();
                 return doc;
             }
 
@@ -181,7 +180,7 @@ namespace tigl {
                 TixiRegisterNamespacesFromDocument(m_handle);
             }
 
-            void registerNamespaces(const std::string& namespaceURI, const std::string& prefix) {
+            void registerNamespace(const std::string& namespaceURI, const std::string& prefix) {
                 TixiRegisterNamespace(m_handle, namespaceURI, prefix);
             }
 

--- a/src/TixiHelper.cpp
+++ b/src/TixiHelper.cpp
@@ -551,5 +551,13 @@ namespace tigl
                 throw TixiError(ret, "Failed to register all document namespaces");
             }
         }
+
+        void TixiRegisterNamespace(const TixiDocumentHandle& tixiHandle, const std::string& namespaceURI, const std::string& prefix)
+        {
+            const ReturnCode ret =  tixiRegisterNamespace(tixiHandle, namespaceURI.c_str(), prefix.c_str());
+            if (ret != SUCCESS) {
+                throw TixiError(ret, "Failed to register all document namespaces");
+            }
+        }
     }
 }

--- a/src/TixiHelper.h
+++ b/src/TixiHelper.h
@@ -122,6 +122,8 @@ namespace tigl
         std::string TixiExportDocumentAsString(const TixiDocumentHandle& tixiHandle);
 
         void TixiRegisterNamespacesFromDocument(const TixiDocumentHandle& tixiHandle);
+        void TixiRegisterNamespace(const TixiDocumentHandle& tixiHandle, const std::string& namespaceURI, const std::string& prefix);
+
 
         template<typename T, typename ReadChildFunc>
         void TixiReadElements(const TixiDocumentHandle& tixiHandle, const std::string& xpath, std::vector<T>& children, ReadChildFunc readChild, int minOccurs = -1, int maxOccurs = -1)


### PR DESCRIPTION
The function tixiRegisterNamespacesFromDocument seems to be very slow on large files. On my win machine, this process took forever. Therefore I registered the "xsd" prefix manually.

Now, things are smooth and fast. Of course, this is a TiXI issue and this is a clear workaround.