### PR TITLE
Only register objects with mandatory uid, if the uid is not empty

### DIFF
--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -688,7 +688,7 @@ namespace tigl {
                 // register
                 if (hasUidField(c)) {
                     if (hasMandatoryUidField(c))
-                        cpp << "if (m_uidMgr) m_uidMgr->RegisterObject(m_uID, *this);";
+                        cpp << "if (m_uidMgr && !m_uID.empty()) m_uidMgr->RegisterObject(m_uID, *this);";
                     else
                         cpp << "if (m_uidMgr && m_uID) m_uidMgr->RegisterObject(*m_uID, *this);";
                 }


### PR DESCRIPTION
This makes sure that TiGL does not give a fatal error if mandatory UIDs are empty.