### PR TITLE
Change style of generated code to conform to TiGL coding style

### DIFF
--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -520,7 +520,8 @@ namespace tigl {
                     createElement();
                     writeReadFunc();
                 }
-                cpp << "} else {";
+                cpp << "}";
+                cpp << "else {";
                 {
                     Scope s(cpp);
                     if (isAtt)
@@ -1159,11 +1160,11 @@ namespace tigl {
                 bool first = true;
                 auto writeMember = [&](const std::string& memberName, const std::string& value) {
                     if (first) {
-                        cpp.raw() << " :";
+                        cpp << ": ";
                         first = false;
                     } else
-                        cpp.raw() << ", ";
-                    cpp << memberName << "(" << value << ")";
+                        cpp << ", ";
+                    cpp.raw() << memberName << "(" << value << ")";
                 };
                 if (hasUid)
                     writeMember("m_uidMgr", "uidMgr");

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1266,8 +1266,6 @@ namespace tigl {
             hpp << "namespace tigl";
             hpp << "{";
             {
-                Scope s(hpp);
-
                 // custom Tigl types declarations
                 for (const auto& fwd : includes.hppCustomForwards)
                     hpp << "class " << fwd << ";";
@@ -1363,7 +1361,7 @@ namespace tigl {
                     }
                 }
 
-                hpp << "}";
+                hpp << "} // namespace generated";
                 hpp << "";
 
                 // export non-custom types into tigl namespace
@@ -1405,7 +1403,7 @@ namespace tigl {
                     }
                 }
             }
-            hpp << "}";
+            hpp << "} // namespace tigl";
             hpp << "";
         }
 
@@ -1423,8 +1421,6 @@ namespace tigl {
             cpp << "namespace tigl";
             cpp << "{";
             {
-                Scope s(cpp);
-
                 cpp << "namespace generated";
                 cpp << "{";
                 {
@@ -1464,9 +1460,9 @@ namespace tigl {
                         cpp << "}";
                     }
                 }
-                cpp << "}";
+                cpp << "} // namespace generated";
             }
-            cpp << "}";
+            cpp << "} // namespace tigl";
             cpp << "";
         }
 
@@ -1515,7 +1511,6 @@ namespace tigl {
             hpp << "namespace tigl";
             hpp << "{";
             {
-                Scope s(hpp);
 
                 hpp << "namespace generated";
                 hpp << "{";
@@ -1596,7 +1591,7 @@ namespace tigl {
                         hpp << "}";
                     }
                 }
-                hpp << "}";
+                hpp << "} // namespace generated";
                 hpp << "";
 
                 // export non-custom types into tigl namespace
@@ -1632,7 +1627,7 @@ namespace tigl {
                     }
                 }
             }
-            hpp << "}";
+            hpp << "} // namespace tigl";
             hpp << "";
         }
     };

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -280,7 +280,7 @@ namespace tigl {
                     hpp << "{";
                     {
                         Scope s(hpp);
-                        hpp << "#ifdef HAVE_STDIS_SAME";
+                        hpp.raw() << "\n#ifdef HAVE_STDIS_SAME";
                         hpp << "static_assert(";
                         for (const auto& dep : c.deps.parents) {
                             if (&dep != &c.deps.parents[0])
@@ -288,7 +288,7 @@ namespace tigl {
                             hpp.raw() << "std::is_same<P, " << customReplacedType(dep->name) << ">::value";
                         }
                         hpp.raw() << ", \"template argument for P is not a parent class of " << c.name << "\");";
-                        hpp << "#endif";
+                        hpp.raw() << "\n#endif";
                         if (c_generateDefaultCtorsForParentPointerTypes) {
                             hpp << "if (m_parent == NULL) {";
                             {
@@ -1342,16 +1342,16 @@ namespace tigl {
                         Scope s(hpp);
 
                         // copy ctor and assign, move ctor and assign
-                        hpp << "#ifdef HAVE_CPP11";
+                        hpp.raw() << "\n#ifdef HAVE_CPP11";
                         hpp << c.name << "(const " << c.name << "&) = delete;";
                         hpp << "" << c.name << "& operator=(const " << c.name << "&) = delete;";
                         hpp << "";
                         hpp << c.name << "(" << c.name << "&&) = delete;";
                         hpp << c.name << "& operator=(" << c.name << "&&) = delete;";
-                        hpp << "#else";
+                        hpp.raw() << "\n#else";
                         hpp << c.name << "(const " << c.name << "&);";
                         hpp << c.name << "& operator=(const " << c.name << "&);";
-                        hpp << "#endif";
+                        hpp.raw() << "\n#endif";
                     }
                     hpp << "};";
 
@@ -1389,13 +1389,13 @@ namespace tigl {
                         ops = boost::in_place(std::ref(hpp));
                     }
 
-                    hpp << "#ifdef HAVE_CPP11";
+                    hpp.raw() << "\n#ifdef HAVE_CPP11";
                     for (const auto& name : exportedTypes)
                         hpp << "using C" << name << " = " << generatedNs << "::" << name << ";";
-                    hpp << "#else";
+                    hpp.raw() << "\n#else";
                     for (const auto& name : exportedTypes)
                         hpp << "typedef " << generatedNs << "::" << name << " C" << name << ";";
-                    hpp << "#endif";
+                    hpp.raw() << "\n#endif";
 
                     if (!m_namespace.empty()) {
                         ops = boost::none;
@@ -1611,12 +1611,12 @@ namespace tigl {
                     }
 
                     if (!c_generateCpp11ScopedEnums)
-                        hpp << "#ifdef HAVE_CPP11";
+                        hpp.raw() << "\n#ifdef HAVE_CPP11";
                     hpp << "using E" << e.name << " = " << generatedNs << "::" << e.name << ";";
                     if (!c_generateCpp11ScopedEnums) {
-                        hpp << "#else";
+                        hpp.raw() << "\n#else";
                         hpp << "typedef " << generatedNs << "::" << e.name << " E" << e.name << ";";
-                        hpp << "#endif";
+                        hpp.raw() << "\n#endif";
                         for (const auto& v : e.values)
                             hpp << "using " << generatedNs << "::" << enumCppName(v.name(), m_tables) << ";";
                     }

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1218,7 +1218,8 @@ namespace tigl {
             } else {
                 cpp << c.name << "::" << c.name << "(" << (hasUid ? c_uidMgrName + "* uidMgr" : "") << ")";
                 writeInitializationList();
-                cpp.raw() << " {}";
+                cpp << "{";
+                cpp << "}";
                 cpp << "";
             }
         }
@@ -1240,8 +1241,11 @@ namespace tigl {
                         cpp << "if (m_uidMgr && m_uID) m_uidMgr->TryUnregisterObject(*m_uID);";
                 }
                 cpp << "}";
-            } else
-                cpp << c.name << "::~" << c.name << "() {}";
+            } else {
+                cpp << c.name << "::~" << c.name << "()";
+                cpp << "{";
+                cpp << "}";
+            }
             cpp << "";
         }
 


### PR DESCRIPTION
I just changed some minor things in the code gen, which include:
 - Style of the initializer list
 - Avoid indentation of outer TiGL namespace
 - Avoid indentation of #ifdef etc...

This style is described in the TiGL wiki and can also be forced with clang-format or astyle:
https://github.com/DLR-SC/tigl/wiki/TiGL-Programmers-Guide#tigl-mandatory-c-style-guidelines